### PR TITLE
improve locking and performance of lazyloadingcachepolicy

### DIFF
--- a/configcatclient/readwritelock.py
+++ b/configcatclient/readwritelock.py
@@ -30,3 +30,75 @@ class ReadWriteLock(object):
 
     def release_write(self):
         self.__exclude.release()
+
+
+class RWLock(object):
+    """Synchronization object used in a solution of so-called second 
+    readers-writers problem. In this problem, many readers can simultaneously 
+    access a share, and a writer has an exclusive access to this share.
+    Additionally, the following constraints should be met: 
+    1) no reader should be kept waiting if the share is currently opened for 
+        reading unless a writer is also waiting for the share, 
+    2) no writer should be kept waiting for the share longer than absolutely 
+        necessary. 
+
+    The implementation is based on [1, secs. 4.2.2, 4.2.6, 4.2.7] 
+    with a modification -- adding an additional lock (C{self.__readers_queue})
+    -- in accordance with [2].
+
+    Sources:
+    [1] A.B. Downey: "The little book of semaphores", Version 2.1.5, 2008
+    [2] P.J. Courtois, F. Heymans, D.L. Parnas:
+        "Concurrent Control with 'Readers' and 'Writers'", 
+        Communications of the ACM, 1971 (via [3])
+    [3] http://en.wikipedia.org/wiki/Readers-writers_problem
+    """
+
+    def __init__(self):
+        self.__read_switch = _LightSwitch()
+        self.__write_switch = _LightSwitch()
+        self.__no_readers = threading.Lock()
+        self.__no_writers = threading.Lock()
+        self.__readers_queue = threading.Lock()
+        """A lock giving an even higher priority to the writer in certain
+        cases (see [2] for a discussion)"""
+
+    def acquire_read(self):
+        self.__readers_queue.acquire()
+        self.__no_readers.acquire()
+        self.__read_switch.acquire(self.__no_writers)
+        self.__no_readers.release()
+        self.__readers_queue.release()
+
+    def release_read(self):
+        self.__read_switch.release(self.__no_writers)
+
+    def acquire_write(self):
+        self.__write_switch.acquire(self.__no_readers)
+        self.__no_writers.acquire()
+
+    def release_write(self):
+        self.__no_writers.release()
+        self.__write_switch.release(self.__no_readers)
+
+
+class _LightSwitch(object):
+    """An auxiliary "light switch"-like object. The first thread turns on the 
+    "switch", the last one turns it off (see [1, sec. 4.2.2] for details)."""
+    def __init__(self):
+        self.__counter = 0
+        self.__mutex = threading.Lock()
+
+    def acquire(self, lock):
+        self.__mutex.acquire()
+        self.__counter += 1
+        if self.__counter == 1:
+            lock.acquire()
+        self.__mutex.release()
+
+    def release(self, lock):
+        self.__mutex.acquire()
+        self.__counter -= 1
+        if self.__counter == 0:
+            lock.release()
+        self.__mutex.release()

--- a/configcatclienttests/test_lazyloadingcachepolicy.py
+++ b/configcatclienttests/test_lazyloadingcachepolicy.py
@@ -54,12 +54,16 @@ class LazyLoadingCachePolicyTests(unittest.TestCase):
         self.assertEqual(value, TEST_JSON)
         self.assertEqual(config_fetcher.get_call_count, 1)
 
-        # Get value from Config Store, which indicates a config_fetcher call after cache invalidation
-        cache_policy.force_refresh()
-        value = cache_policy.get()
-        self.assertEqual(value, TEST_JSON)
-        self.assertEqual(config_fetcher.get_call_count, 2)
-        cache_policy.stop()
+        with mock.patch('configcatclient.lazyloadingcachepolicy.datetime') as mock_datetime:
+            # assume 160 seconds has elapsed since the last call enough to do a 
+            # force refresh
+            mock_datetime.datetime.utcnow.return_value = cache_policy._last_updated + datetime.timedelta(seconds=161)
+            # Get value from Config Store, which indicates a config_fetcher call after cache invalidation
+            cache_policy.force_refresh()
+            value = cache_policy.get()
+            self.assertEqual(value, TEST_JSON)
+            self.assertEqual(config_fetcher.get_call_count, 2)
+            cache_policy.stop()
 
     def test_force_refresh_honours_304(self):
         config_fetcher = mock.MagicMock()
@@ -81,13 +85,43 @@ class LazyLoadingCachePolicyTests(unittest.TestCase):
             self.assertEqual(value, TEST_JSON)
             self.assertEqual(successful_response.json.call_count, 1)
             config_fetcher.get_configuration_json.return_value = FetchResponse(not_modified_response)
+            new_time = datetime.datetime(2020, 5, 20, 0, 0, 0) + datetime.timedelta(seconds=161)
+            mock_datetime.datetime.utcnow.return_value = new_time
             cache_policy.force_refresh()
-            self.assertEqual(value, TEST_JSON)
             self.assertEqual(config_fetcher.get_configuration_json.call_count, 2)
             # this indicates that is_fetched() was correctly called and
             # the setting of the new last updated didn't occur
             self.assertEqual(not_modified_response.json.call_count, 0)
+            self.assertEqual(mock_datetime.datetime.utcnow.call_count, 4)
+            # last updated should still be set in the case of a 304
+            self.assertEqual(cache_policy._last_updated, new_time)
         cache_policy.stop()
+
+    def test_force_refresh_skips_hitting_api_after_update(self):
+        config_fetcher = mock.MagicMock()
+        successful_response = mock.MagicMock()
+        successful_response.status_code = 200
+        successful_response.json.return_value = TEST_JSON
+        config_fetcher.get_configuration_json.return_value = FetchResponse(successful_response)
+        config_cache = InMemoryConfigCache()
+        cache_policy = LazyLoadingCachePolicy(config_fetcher, config_cache, 160)
+
+        # Get value from Config Store, which indicates a config_fetcher call
+        with mock.patch('configcatclient.lazyloadingcachepolicy.datetime') as mock_datetime:
+            now = datetime.datetime(2020, 5, 20, 0, 0, 0)
+            mock_datetime.datetime.utcnow.return_value = now
+            self.assertIsNone(cache_policy._last_updated)
+            cache_policy.force_refresh()
+            self.assertEqual(config_fetcher.get_configuration_json.call_count, 1)
+            # when the cache timeout is still within the limit skip any network
+            # requests, as this could be that multiple threads have attempted
+            # to acquire the lock at the same time, but only really one needs to update
+            cache_policy._last_updated = now - datetime.timedelta(seconds=159)
+            cache_policy.force_refresh()
+            self.assertEqual(config_fetcher.get_configuration_json.call_count, 1)
+            cache_policy._last_updated = now - datetime.timedelta(seconds=161)
+            cache_policy.force_refresh()
+            self.assertEqual(config_fetcher.get_configuration_json.call_count, 2)
 
     def test_http_error(self):
         config_fetcher = ConfigFetcherWithErrorMock(HTTPError("error"))

--- a/configcatclienttests/test_lazyloadingcachepolicy.py
+++ b/configcatclienttests/test_lazyloadingcachepolicy.py
@@ -69,7 +69,7 @@ class LazyLoadingCachePolicyTests(unittest.TestCase):
         not_modified_response = mock.MagicMock()
         not_modified_response.status_code = 304
         not_modified_response.json.side_effect = ValueError("this response contains no body")
-        config_fetcher.get_configuration_json.return_value = successful_response
+        config_fetcher.get_configuration_json.return_value = FetchResponse(successful_response)
         config_cache = InMemoryConfigCache()
         cache_policy = LazyLoadingCachePolicy(config_fetcher, config_cache, 160)
 
@@ -79,13 +79,14 @@ class LazyLoadingCachePolicyTests(unittest.TestCase):
             value = cache_policy.get()
             self.assertEqual(mock_datetime.datetime.utcnow.call_count, 2)
             self.assertEqual(value, TEST_JSON)
-            config_fetcher.get_configuration_json.return_value = not_modified_response
+            self.assertEqual(successful_response.json.call_count, 1)
+            config_fetcher.get_configuration_json.return_value = FetchResponse(not_modified_response)
             cache_policy.force_refresh()
             self.assertEqual(value, TEST_JSON)
             self.assertEqual(config_fetcher.get_configuration_json.call_count, 2)
             # this indicates that is_fetched() was correctly called and
             # the setting of the new last updated didn't occur
-            self.assertEqual(mock_datetime.datetime.utcnow.call_count, 2)
+            self.assertEqual(not_modified_response.json.call_count, 0)
         cache_policy.stop()
 
     def test_http_error(self):


### PR DESCRIPTION
It was noticed that when running in a multi threaded environment
that if multiple subsequent requests were sent to the configcatclient
with the lazyloadingcachepolicy it would end up causing a couple
of issues.
- multiple threads could attempt to read and all
  attempt to force_reset with them all waiting for
  the write lock as they had a successful request at
  the same time before the etag was updated.
- that multiple requests could starve a write acquisition
  from gaining access as the readers would not give up lock
- that when the content was not modified that subsequent
  requests and attempts to read values would all have to
  send a request to the configcat servers and get a 304
  but not update the _last_updated flag.

To solve these problems
- a lock that preferences writer acquisition was added
- even on a not modified 304 response from config cat
  set the cache timeout/last updated to now.
- return early if a write has been done whilst waiting
  to acquire the write lock. To reduce requests to
  config cat