### PR TITLE
add new read write lock that prioritises writers

### DIFF
--- a/configcatclient/lazyloadingcachepolicy.py
+++ b/configcatclient/lazyloadingcachepolicy.py
@@ -3,7 +3,7 @@ import sys
 import datetime
 from requests import HTTPError
 
-from .readwritelock import RWLock
+from .readwritelock import ReadWriteLock
 from .interfaces import CachePolicy
 
 log = logging.getLogger(sys.modules[__name__].__name__)
@@ -17,7 +17,7 @@ class LazyLoadingCachePolicy(CachePolicy):
         self._config_fetcher = config_fetcher
         self._config_cache = config_cache
         self._cache_time_to_live = datetime.timedelta(seconds=cache_time_to_live_seconds)
-        self._lock = RWLock()
+        self._lock = ReadWriteLock()
         self._last_updated = None
 
     def get(self):

--- a/configcatclient/lazyloadingcachepolicy.py
+++ b/configcatclient/lazyloadingcachepolicy.py
@@ -3,7 +3,7 @@ import sys
 import datetime
 from requests import HTTPError
 
-from .readwritelock import ReadWriteLock
+from .readwritelock import RWLock
 from .interfaces import CachePolicy
 
 log = logging.getLogger(sys.modules[__name__].__name__)
@@ -17,7 +17,7 @@ class LazyLoadingCachePolicy(CachePolicy):
         self._config_fetcher = config_fetcher
         self._config_cache = config_cache
         self._cache_time_to_live = datetime.timedelta(seconds=cache_time_to_live_seconds)
-        self._lock = ReadWriteLock()
+        self._lock = RWLock()
         self._last_updated = None
 
     def get(self):

--- a/configcatclient/readwritelock.py
+++ b/configcatclient/readwritelock.py
@@ -30,3 +30,75 @@ class ReadWriteLock(object):
 
     def release_write(self):
         self.__exclude.release()
+
+
+class RWLock(object):
+    """Synchronization object used in a solution of so-called second 
+    readers-writers problem. In this problem, many readers can simultaneously 
+    access a share, and a writer has an exclusive access to this share.
+    Additionally, the following constraints should be met: 
+    1) no reader should be kept waiting if the share is currently opened for 
+        reading unless a writer is also waiting for the share, 
+    2) no writer should be kept waiting for the share longer than absolutely 
+        necessary. 
+
+    The implementation is based on [1, secs. 4.2.2, 4.2.6, 4.2.7] 
+    with a modification -- adding an additional lock (C{self.__readers_queue})
+    -- in accordance with [2].
+
+    Sources:
+    [1] A.B. Downey: "The little book of semaphores", Version 2.1.5, 2008
+    [2] P.J. Courtois, F. Heymans, D.L. Parnas:
+        "Concurrent Control with 'Readers' and 'Writers'", 
+        Communications of the ACM, 1971 (via [3])
+    [3] http://en.wikipedia.org/wiki/Readers-writers_problem
+    """
+
+    def __init__(self):
+        self.__read_switch = _LightSwitch()
+        self.__write_switch = _LightSwitch()
+        self.__no_readers = threading.Lock()
+        self.__no_writers = threading.Lock()
+        self.__readers_queue = threading.Lock()
+        """A lock giving an even higher priority to the writer in certain
+        cases (see [2] for a discussion)"""
+
+    def acquire_read(self):
+        self.__readers_queue.acquire()
+        self.__no_readers.acquire()
+        self.__read_switch.acquire(self.__no_writers)
+        self.__no_readers.release()
+        self.__readers_queue.release()
+
+    def release_read(self):
+        self.__read_switch.release(self.__no_writers)
+
+    def acquire_write(self):
+        self.__write_switch.acquire(self.__no_readers)
+        self.__no_writers.acquire()
+
+    def release_write(self):
+        self.__no_writers.release()
+        self.__write_switch.release(self.__no_readers)
+
+
+class _LightSwitch(object):
+    """An auxiliary "light switch"-like object. The first thread turns on the 
+    "switch", the last one turns it off (see [1, sec. 4.2.2] for details)."""
+    def __init__(self):
+        self.__counter = 0
+        self.__mutex = threading.Lock()
+
+    def acquire(self, lock):
+        self.__mutex.acquire()
+        self.__counter += 1
+        if self.__counter == 1:
+            lock.acquire()
+        self.__mutex.release()
+
+    def release(self, lock):
+        self.__mutex.acquire()
+        self.__counter -= 1
+        if self.__counter == 0:
+            lock.release()
+        self.__mutex.release()

--- a/configcatclient/readwritelock.py
+++ b/configcatclient/readwritelock.py
@@ -2,37 +2,6 @@ import threading
 
 
 class ReadWriteLock(object):
-    """ An implementation of a read-write lock for Python.
-    Any number of readers can work simultaneously but they
-    are mutually exclusive with any writers (which can
-    only have one at a time).
-    """
-
-    def __init__(self):
-        self.__monitor = threading.Lock()
-        self.__exclude = threading.Lock()
-        self.readers = 0
-
-    def acquire_read(self):
-        with self.__monitor:
-            self.readers += 1
-            if self.readers == 1:
-                self.__exclude.acquire()
-
-    def release_read(self):
-        with self.__monitor:
-            self.readers -= 1
-            if self.readers == 0:
-                self.__exclude.release()
-
-    def acquire_write(self):
-        self.__exclude.acquire()
-
-    def release_write(self):
-        self.__exclude.release()
-
-
-class RWLock(object):
     """Synchronization object used in a solution of so-called second 
     readers-writers problem. In this problem, many readers can simultaneously 
     access a share, and a writer has an exclusive access to this share.


### PR DESCRIPTION
This adds a new read write lock to allow writers to
have priority if acquiring the lock so that they
don't get starved by continued readers adding to the queue.